### PR TITLE
Fix/twilio validation

### DIFF
--- a/app/core/twilio_logic.py
+++ b/app/core/twilio_logic.py
@@ -153,19 +153,6 @@ def twilio_background_task(request: Request, data: dict) -> dict | None:
         dict: dictionary of extracted data for future processing
         None: returned on error.
     """
-    if not validate_twilio_request(request, data):
-        failure_log = LogEntry(
-            level="ERROR",
-            message="Twilio request is invalid",
-            service_name="Twilio Webhook",
-            trace_id=request.headers.get("X-Twilio-Trace-ID", "None"),
-            context={
-                "message_sid": data.get("MessageSid", "")
-            }
-        )
-        logging.error(failure_log.to_json())
-        return None
-
     try:
         client = get_client()
         msg_sid = data.get("MessageSid")

--- a/app/core/twilio_logic.py
+++ b/app/core/twilio_logic.py
@@ -140,13 +140,12 @@ def sanitize_data(data: dict) -> dict:
     }
 
 
-def twilio_background_task(request: Request, data: dict) -> dict | None:
+def twilio_background_task(request_headers: dict, data: dict) -> dict | None:
     """
     Function to be called as a background task
     Runs all functions needed to process twilio messages
 
     Args:
-        request: Request to fastAPI endpoint
         data: Raw twilio request data. (Must not be modified for validator to work)
 
     Returns:
@@ -174,7 +173,7 @@ def twilio_background_task(request: Request, data: dict) -> dict | None:
             level="INFO",
             message="SMS Processed Successfully",
             service_name="Twilio Webhook",
-            trace_id=request.headers.get("X-Twilio-Trace-ID", "None"),
+            trace_id=request_headers.get("X-Twilio-Trace-ID", "None"),
             context=sanitize_data(data),
         )
         logging.info(success_log.to_json())
@@ -194,7 +193,7 @@ def twilio_background_task(request: Request, data: dict) -> dict | None:
             level="ERROR",
             message= str(e),
             service_name="Twilio Webhook",
-            trace_id=request.headers.get("X-Twilio-Trace-ID", "None"),
+            trace_id=request_headers.get("X-Twilio-Trace-ID", "None"),
             context=sanitized_data,
         )
         logging.error(failure_log.to_json())

--- a/tests/test_twilio_logic.py
+++ b/tests/test_twilio_logic.py
@@ -126,7 +126,6 @@ class TwilioLogicTest(unittest.TestCase):
     @patch.dict(os.environ, {'MY_EMAIL': 'email@example.com'})
     @patch('app.core.twilio_logic.get_routes')
     @patch('app.core.twilio_logic.EmailSender')
-    @patch('app.core.twilio_logic.validate_twilio_request')
     @patch('app.core.twilio_logic.get_client')
     @patch('app.core.twilio_logic.get_full_twilio_data')
     @patch('app.core.twilio_logic.extract_message_info')
@@ -135,7 +134,6 @@ class TwilioLogicTest(unittest.TestCase):
             mock_extract_message_info,
             mock_get_full_twilio_data,
             mock_get_client,
-            mock_validate_twilio_request,
             mock_email_sender,
             mock_get_routes,
         ):
@@ -150,8 +148,6 @@ class TwilioLogicTest(unittest.TestCase):
         mock_message_instance.date_created = datetime.now()
         mock_sender_instance = mock_email_sender.return_value
 
-
-        mock_validate_twilio_request.return_value = True
         mock_get_client.return_value = mock_client
         mock_get_full_twilio_data.return_value = mock_message_instance
         mock_extract_message_info.return_value = {
@@ -168,7 +164,6 @@ class TwilioLogicTest(unittest.TestCase):
 
         twilio_background_task(mock_request, mock_data)
 
-        mock_validate_twilio_request.assert_called_once_with(mock_request, mock_data)
         mock_get_client.assert_called_once()
         mock_get_full_twilio_data.assert_called_once_with(mock_client, mock_data['MessageSid'])
         mock_extract_message_info.assert_called_once_with(mock_message_instance)

--- a/tests/test_twilio_logic.py
+++ b/tests/test_twilio_logic.py
@@ -137,9 +137,8 @@ class TwilioLogicTest(unittest.TestCase):
             mock_email_sender,
             mock_get_routes,
         ):
-        mock_request = MagicMock()
-        mock_request.url.path = '/webhooks/twilio'
-        mock_request.headers = {'X-Twilio-Signature': 'fake_signature'}
+
+        mock_request_headers = {'X-Twilio-Signature': 'fake_signature'}
         mock_data = {'MessageSid': 'fake_msg_sid', 'key': 'value'}
         mock_client = MagicMock(spec=Client)
         mock_message_instance = MagicMock(spec=MessageInstance)
@@ -162,7 +161,7 @@ class TwilioLogicTest(unittest.TestCase):
             'routes': "email"
         }
 
-        twilio_background_task(mock_request, mock_data)
+        twilio_background_task(mock_request_headers, mock_data)
 
         mock_get_client.assert_called_once()
         mock_get_full_twilio_data.assert_called_once_with(mock_client, mock_data['MessageSid'])


### PR DESCRIPTION
Fixes Bug Related to Production Deployment

This PR moves the Twilio Message Validation into the endpoint itself.
Resolves an issue around the lifespan of the request when being passed to the background task and then closing the request. 

Also now pulls out request headers from the request and passes it to the background tasks before responding to the request. 